### PR TITLE
Added support for charset in override

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Express middleware to override the `content-type` header of the request.
 ## Installation
 
 ```bash
-$ npm install --save express-content-type-override  
+$ npm install --save express-content-type-override
 ```
 
 ## Usage
@@ -20,7 +20,8 @@ var bodyParser = require('body-parser');
 var registrationController = require('./controllers/registrationController');
 
 server.use( '/registration', contentTypeOverride({
-    contentType: 'application/x-www-form-urlencoded'
+    contentType: 'application/x-www-form-urlencoded',
+    charset: 'utf-8'
 }));
 server.use( bodyParser.json() );
 server.use( bodyParser.urlencoded({
@@ -33,8 +34,11 @@ app.listen( 3000 );
 ```
 
 ## Options
-**contentType**  
+**contentType**
 Specify the `content-type` mime-type you'd like to use. Defaults to `application/x-www-form-urlencoded`.
+
+**charset**
+If you need to specify charset as part of `content-type`. No default, will not be part of `content-type` if not set.
 
 ## License
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -10,15 +10,19 @@
  */
 
 module.exports = function ( options ) {
+    var contentType;
     options = options || {};
-    options.contentType = options.contentType || 'application/x-www-form-urlencoded';
-    
+    contentType = options.contentType || 'application/x-www-form-urlencoded';
+    if (options.charset) {
+        contentType += ';charset=' + options.charset;
+    }
+
     return function( req, res, next ) {
-        if ( !req.headers['content-type'] || !req.headers['content-type'].match( options.contentType ) ) {
+        if ( !req.headers['content-type'] || !req.headers['content-type'].match( contentType ) ) {
             // Set the content-type header manually
-            req.headers['content-type'] = options.contentType;
+            req.headers['content-type'] = contentType;
         }
-        
+
         next();
     };
 };

--- a/test/express-content-type-override.js
+++ b/test/express-content-type-override.js
@@ -28,7 +28,7 @@ describe('contentTypeOverride()', function() {
         .expect('Content-Type', /json/)
         .expect(200, '{}', done);
     });
-    
+
     it('should set the content-type header to text/plain', function(done) {
         server = createServer( 'text/plain' );
         request(server)
@@ -36,14 +36,24 @@ describe('contentTypeOverride()', function() {
         .expect('Content-Type', /plain/)
         .expect(200, '{}', done);
     });
+
+    it('should be able to set a charset', function(done) {
+        server = createServer( 'application/json', 'utf-8' );
+        request(server)
+        .post('/')
+        .expect('Content-Type', /json/)
+        .expect('Content-Type', /utf-8/)
+        .expect(200, '{}', done);
+    });
 });
 
-function createServer( contentType ) {
+function createServer( contentType, charset ) {
     var express = require('express');
     var server = express();
 
     server.use('/', contentTypeOverride({
-        contentType: contentType
+        contentType: contentType,
+        charset: charset
     }));
 
     server.post('/', function(req, res) {


### PR DESCRIPTION
Hope you don’t mind a PR. Thanks for putting this up. Helped me out a lot with a bug I had. But as I need charset to be part of the content-type, I created this pull request in case this is something someone else needs.
